### PR TITLE
:sparkles: Prepare janitor for initial version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'AWS Janitor'
 author: 'Rancher Sandbox'
-description: 'Clean-up AWS resources based on a TTL.'
+description: 'Mark and clean AWS resources.'
 inputs: 
   regions:
     description: 'A comma separated list of regions to clean resources in. You can use * for all regions.'
@@ -9,13 +9,14 @@ inputs:
     description: 'Set to true if you want to allow cleaning resources in all regions. If true then * must be used for regions.'
     required: false
     default: 'false'
-  ttl:
-    description: 'The duration that a resource can live for. For example, use 24h for 1 day.'
-    required: true
   commit:
     description: 'Should the action just report or do the actual delete.'
     required: false
     default: 'false'
+  ignore-tag:
+    description: 'The name of the tag that indicates a resource should not be deleted. Defaults to `janitor-ignore`'
+    required: false
+    default: 'janitor-ignore'
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/rancher-sandbox/aws-janitor:v0.1.0'

--- a/action/cleanup.go
+++ b/action/cleanup.go
@@ -2,15 +2,18 @@ package action
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
+const (
+	DeletionTag = "aws-janitor/marked-for-deletion"
+)
+
 type CleanupScope struct {
-	Session *session.Session
-	TTL     time.Duration
-	Commit  bool
+	Session   *session.Session
+	Commit    bool
+	IgnoreTag string
 }
 
 type CleanupFunc func(ctx context.Context, input *CleanupScope) error

--- a/action/cleanup_asg.go
+++ b/action/cleanup_asg.go
@@ -3,7 +3,6 @@ package action
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -15,12 +14,32 @@ func (a *action) cleanASGs(ctx context.Context, input *CleanupScope) error {
 	asgToDelete := []*autoscaling.Group{}
 	pageFunc := func(page *autoscaling.DescribeAutoScalingGroupsOutput, _ bool) bool {
 		for _, asg := range page.AutoScalingGroups {
-			maxAge := asg.CreatedTime.Add(input.TTL)
+			var ignore, markedForDeletion bool
+			for _, tag := range asg.Tags {
+				if *tag.Key == input.IgnoreTag {
+					ignore = true
+				} else if *tag.Key == DeletionTag {
+					markedForDeletion = true
+				}
+			}
 
-			if time.Now().Before(maxAge) {
-				LogDebug("asg %s has max age greater than now, skipping cleanup", *asg.AutoScalingGroupName)
+			if ignore {
+				LogDebug("asg %s has ignore tag, skipping cleanup", *asg.AutoScalingGroupName)
 				continue
 			}
+
+			if !markedForDeletion {
+				// NOTE: only mark for future deletion if we're not running in dry-mode
+				if a.commit {
+					LogDebug("asg %s does not have deletion tag, marking for future deletion and skipping cleanup", *asg.AutoScalingGroupName)
+					if err := a.markAsgForFutureDeletion(ctx, *asg.AutoScalingGroupName, client); err != nil {
+						LogError("failed to mark asg %s for future deletion: %s", *asg.AutoScalingGroupName, err.Error())
+					}
+				}
+				continue
+			}
+
+			LogDebug("adding asg %s to delete list", *asg.AutoScalingGroupName)
 			asgToDelete = append(asgToDelete, asg)
 		}
 
@@ -61,4 +80,20 @@ func (a *action) cleanASGs(ctx context.Context, input *CleanupScope) error {
 	}
 
 	return nil
+}
+
+func (a *action) markAsgForFutureDeletion(ctx context.Context, asgName string, client *autoscaling.AutoScaling) error {
+	Log("Marking ASG %s for future deletion", asgName)
+
+	_, err := client.CreateOrUpdateTagsWithContext(ctx, &autoscaling.CreateOrUpdateTagsInput{Tags: []*autoscaling.Tag{
+		{
+			Key:               aws.String(DeletionTag),
+			PropagateAtLaunch: aws.Bool(true),
+			ResourceId:        aws.String(asgName),
+			ResourceType:      aws.String("auto-scaling-group"),
+			Value:             aws.String("true"),
+		},
+	}})
+
+	return err
 }

--- a/action/cleanup_cf.go
+++ b/action/cleanup_cf.go
@@ -1,0 +1,114 @@
+package action
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	cf "github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+func (a *action) cleanCfStacks(ctx context.Context, input *CleanupScope) error {
+	client := cf.New(input.Session)
+
+	stacksToDelete := []*string{}
+	pageFunc := func(page *cf.DescribeStacksOutput, _ bool) bool {
+		for _, stack := range page.Stacks {
+			var ignore, markedForDeletion bool
+			for _, tag := range stack.Tags {
+				if *tag.Key == input.IgnoreTag {
+					ignore = true
+				} else if *tag.Key == DeletionTag {
+					markedForDeletion = true
+				}
+			}
+
+			if ignore {
+				LogDebug("cloudformation stack %s has ignore tag, skipping cleanup", *stack.StackName)
+				continue
+			}
+
+			if !markedForDeletion {
+				// NOTE: only mark for future deletion if we're not running in dry-mode
+				if a.commit {
+					LogDebug("cloudformation stack %s does not have deletion tag, marking for future deletion and skipping cleanup", *stack.StackName)
+					if err := a.markCfStackForFutureDeletion(ctx, stack, client); err != nil {
+						LogError("failed to mark cloudformation stack %s for future deletion: %s", *stack.StackName, err.Error())
+					}
+				}
+				continue
+			}
+
+			switch aws.StringValue(stack.StackStatus) {
+			case cf.ResourceStatusDeleteComplete,
+				cf.ResourceStatusDeleteInProgress:
+				LogDebug("cloudformation stack %s is already deleted/deleting, skipping cleanup", *stack.StackName)
+				continue
+			}
+
+			LogDebug("adding cloudformation stack %s to delete list", *stack.StackName)
+			stacksToDelete = append(stacksToDelete, stack.StackName)
+		}
+
+		return true
+	}
+
+	if err := client.DescribeStacksPagesWithContext(ctx, &cf.DescribeStacksInput{}, pageFunc); err != nil {
+		return fmt.Errorf("failed getting list of cloudformation stacks: %w", err)
+	}
+
+	if len(stacksToDelete) == 0 {
+		Log("no cloudformation stacks to delete")
+		return nil
+	}
+
+	for _, stackName := range stacksToDelete {
+		if !a.commit {
+			LogDebug("skipping deletion of cloudformation stack %s as running in dry-mode", *stackName)
+			continue
+		}
+
+		if err := a.deleteCfStack(ctx, *stackName, client); err != nil {
+			LogError("failed to delete cloudformation stack %s: %s", *stackName, err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (a *action) markCfStackForFutureDeletion(ctx context.Context, stack *cf.Stack, client *cf.CloudFormation) error {
+	Log("Marking CloudFormation stack %s for future deletion", *stack.StackName)
+
+	stack.SetTags(append(stack.Tags, &cf.Tag{Key: aws.String(DeletionTag), Value: aws.String("true")}))
+
+	LogDebug("Updating tags for cloudformation stack %s", *stack.StackName)
+
+	if _, err := client.UpdateStackWithContext(ctx, &cf.UpdateStackInput{
+		Capabilities:        stack.Capabilities,
+		StackName:           stack.StackName,
+		Tags:                stack.Tags,
+		UsePreviousTemplate: aws.Bool(true),
+	}); err != nil {
+		return fmt.Errorf("failed to update cloudformation stack %s: %w", *stack.StackName, err)
+	}
+
+	if err := client.WaitUntilStackUpdateCompleteWithContext(ctx, &cf.DescribeStacksInput{StackName: stack.StackName}); err != nil {
+		return fmt.Errorf("failed to wait for cloudformation stack %s to update: %w", *stack.StackName, err)
+	}
+
+	return nil
+}
+
+func (a *action) deleteCfStack(ctx context.Context, stackName string, client *cf.CloudFormation) error {
+	Log("Deleting CloudFormation stack %s", stackName)
+
+	if _, err := client.DeleteStackWithContext(ctx, &cf.DeleteStackInput{StackName: &stackName}); err != nil {
+		return fmt.Errorf("failed to delete cloudformation stack %s: %w", stackName, err)
+	}
+
+	if err := client.WaitUntilStackDeleteCompleteWithContext(ctx, &cf.DescribeStacksInput{StackName: &stackName}); err != nil {
+		return fmt.Errorf("failed to wait for cloudformation stack %s to delete: %w", stackName, err)
+	}
+
+	return nil
+}

--- a/action/cleanup_lb.go
+++ b/action/cleanup_lb.go
@@ -1,0 +1,101 @@
+package action
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elb"
+)
+
+func (a *action) cleanLoadBalancers(ctx context.Context, input *CleanupScope) error {
+	client := elb.New(input.Session)
+
+	loadBalancersToDelete := []*string{}
+	pageFunc := func(page *elb.DescribeLoadBalancersOutput, _ bool) bool {
+		for _, lb := range page.LoadBalancerDescriptions {
+			tags, err := client.DescribeTagsWithContext(ctx, &elb.DescribeTagsInput{LoadBalancerNames: []*string{lb.LoadBalancerName}})
+			if err != nil {
+				LogError("failed getting tags for load balancer %s: %s", *lb.LoadBalancerName, err.Error())
+			}
+
+			var ignore, markedForDeletion bool
+			for _, tagDescription := range tags.TagDescriptions {
+				for _, tag := range tagDescription.Tags {
+					if *tag.Key == input.IgnoreTag {
+						ignore = true
+					} else if *tag.Key == DeletionTag {
+						markedForDeletion = true
+					}
+				}
+			}
+
+			if ignore {
+				LogDebug("load balancer %s has ignore tag, skipping cleanup", *lb.LoadBalancerName)
+				continue
+			}
+
+			if !markedForDeletion {
+				// NOTE: only mark for future deletion if we're not running in dry-mode
+				if a.commit {
+					LogDebug("load balancer %s does not have deletion tag, marking for future deletion and skipping cleanup", *lb.LoadBalancerName)
+					if err := a.markLoadBalancerForFutureDeletion(ctx, *lb.LoadBalancerName, client); err != nil {
+						LogError("failed to mark load balancer %s for future deletion: %s", *lb.LoadBalancerName, err.Error())
+					}
+				}
+				continue
+			}
+
+			LogDebug("adding load balancer %s to delete list", *lb.LoadBalancerName)
+			loadBalancersToDelete = append(loadBalancersToDelete, lb.LoadBalancerName)
+		}
+
+		return true
+	}
+
+	if err := client.DescribeLoadBalancersPagesWithContext(ctx, &elb.DescribeLoadBalancersInput{}, pageFunc); err != nil {
+		return fmt.Errorf("failed getting list of load balancer: %w", err)
+	}
+
+	if len(loadBalancersToDelete) == 0 {
+		Log("no load balancer to delete")
+		return nil
+	}
+
+	for _, lbName := range loadBalancersToDelete {
+		if !a.commit {
+			LogDebug("skipping deletion of load balancer %s as running in dry-mode", *lbName)
+			continue
+		}
+
+		if err := a.deleteLoadBalancer(ctx, *lbName, client); err != nil {
+			LogError("failed to delete load balancer %s: %s", *lbName, err.Error())
+		}
+	}
+
+	return nil
+}
+func (a *action) markLoadBalancerForFutureDeletion(ctx context.Context, lbName string, client *elb.ELB) error {
+	Log("Marking Load Balancer %s for future deletion", lbName)
+
+	_, err := client.AddTagsWithContext(ctx, &elb.AddTagsInput{
+		LoadBalancerNames: []*string{&lbName},
+		Tags: []*elb.Tag{
+			{
+				Key:   aws.String(DeletionTag),
+				Value: aws.String("true")},
+		},
+	})
+
+	return err
+}
+
+func (a *action) deleteLoadBalancer(ctx context.Context, lbName string, client *elb.ELB) error {
+	Log("Deleting Load Balancer %s", lbName)
+
+	if _, err := client.DeleteLoadBalancerWithContext(ctx, &elb.DeleteLoadBalancerInput{LoadBalancerName: &lbName}); err != nil {
+		return fmt.Errorf("failed to delete load balancer %s: %w", lbName, err)
+	}
+
+	return nil
+}

--- a/action/cleanup_sgs.go
+++ b/action/cleanup_sgs.go
@@ -1,0 +1,161 @@
+package action
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func (a *action) cleanSecurityGroups(ctx context.Context, input *CleanupScope) error {
+	client := ec2.New(input.Session)
+
+	sgsToDelete := []*ec2.SecurityGroup{}
+	// NOTE: we delete security groups based on whether we're later deleting the vpc they belong to or not.
+	pageFunc := func(page *ec2.DescribeVpcsOutput, _ bool) bool {
+		sgPageFunc := func(sgPage *ec2.GetSecurityGroupsForVpcOutput, _ bool) bool {
+			for _, sg := range sgPage.SecurityGroupForVpcs {
+				var ignore, markedForDeletion bool
+				for _, tag := range sg.Tags {
+					if *tag.Key == input.IgnoreTag {
+						ignore = true
+					} else if *tag.Key == DeletionTag {
+						markedForDeletion = true
+					}
+				}
+
+				if ignore || *sg.GroupName == "default" {
+					LogDebug("security group %s has ignore tag or is a default security group, skipping cleanup", *sg.GroupId)
+					continue
+				}
+
+				if !markedForDeletion {
+					// NOTE: only mark for future deletion if we're not running in dry-mode
+					if a.commit {
+						LogDebug("security group %s does not have deletion tag, marking for future deletion and skipping cleanup", *sg.GroupId)
+						if err := a.markSecurityGroupForFutureDeletion(ctx, *sg.GroupId, client); err != nil {
+							LogError("failed to mark security group %s for future deletion: %s", *sg.GroupId, err.Error())
+						}
+					}
+					continue
+				}
+
+				securityGroups, err := client.DescribeSecurityGroupsWithContext(ctx, &ec2.DescribeSecurityGroupsInput{GroupIds: []*string{sg.GroupId}})
+				if err != nil || len(securityGroups.SecurityGroups) != 1 {
+					LogError("failed to describe security group %s: %s", *sg.GroupId, err.Error())
+					continue
+				}
+
+				LogDebug("adding security group %s to delete list", *sg.GroupId)
+				sgsToDelete = append(sgsToDelete, securityGroups.SecurityGroups[0])
+			}
+
+			return true
+		}
+
+		for _, vpc := range page.Vpcs {
+			var ignore bool
+			for _, tag := range vpc.Tags {
+				if *tag.Key == input.IgnoreTag {
+					ignore = true
+					break
+				}
+			}
+
+			if ignore || aws.BoolValue(vpc.IsDefault) {
+				LogDebug("vpc %s has ignore tag or is a default vpc, won't delete security groups associated with it", *vpc.VpcId)
+				continue
+			}
+
+			if err := client.GetSecurityGroupsForVpcPagesWithContext(ctx, &ec2.GetSecurityGroupsForVpcInput{VpcId: vpc.VpcId}, sgPageFunc); err != nil {
+				LogError("failed getting list of security groups for vpc %s: %s", *vpc.VpcId, err.Error())
+				continue
+			}
+
+		}
+
+		return true
+	}
+
+	if err := client.DescribeVpcsPagesWithContext(ctx, &ec2.DescribeVpcsInput{}, pageFunc); err != nil {
+		return fmt.Errorf("failed getting list of vpcs: %w", err)
+	}
+
+	if len(sgsToDelete) == 0 {
+		Log("no security groups to delete")
+		return nil
+	}
+
+	// NOTE: some security groups may have rules that reference other security groups.
+	// deleting a security group that's referenced in another's rules will fail,
+	// so we need to delete the rules first.
+	for _, securityGroup := range sgsToDelete {
+		if !a.commit {
+			LogDebug("skipping deletion of security group %s as running in dry-mode", *securityGroup.GroupId)
+			continue
+		}
+
+		if err := a.deleteSecurityGroupRules(ctx, *securityGroup.GroupId, securityGroup.IpPermissions, securityGroup.IpPermissionsEgress, client); err != nil {
+			LogError("failed to delete security group rules for %s: %s", *securityGroup.GroupId, err.Error())
+		}
+
+	}
+
+	for _, securityGroup := range sgsToDelete {
+		if !a.commit {
+			LogDebug("skipping deletion of security group %s as running in dry-mode", *securityGroup.GroupId)
+			continue
+		}
+
+		LogDebug("Sleeping for 10 seconds to allow AWS to catch up")
+		time.Sleep(10 * time.Second)
+
+		if err := a.deleteSecurityGroup(ctx, *securityGroup.GroupId, client); err != nil {
+			LogError("failed to delete security group %s: %s", *securityGroup.GroupId, err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (a *action) markSecurityGroupForFutureDeletion(ctx context.Context, sgId string, client *ec2.EC2) error {
+	Log("Marking Security Group %s for future deletion", sgId)
+
+	_, err := client.CreateTagsWithContext(ctx, &ec2.CreateTagsInput{
+		Resources: []*string{&sgId}, Tags: []*ec2.Tag{
+			{Key: aws.String(DeletionTag), Value: aws.String("true")},
+		},
+	})
+
+	return err
+}
+
+func (a *action) deleteSecurityGroupRules(ctx context.Context, sgId string, sgIngress, sgEgress []*ec2.IpPermission, client *ec2.EC2) error {
+	Log("Deleting Ingress/Egress Rules from security group %s", sgId)
+
+	if len(sgIngress) != 0 {
+		if _, err := client.RevokeSecurityGroupIngressWithContext(ctx, &ec2.RevokeSecurityGroupIngressInput{GroupId: &sgId, IpPermissions: sgIngress}); err != nil {
+			return fmt.Errorf("failed to revoke ingress rules from security group %s: %w", sgId, err)
+		}
+	}
+
+	if len(sgEgress) != 0 {
+		if _, err := client.RevokeSecurityGroupEgressWithContext(ctx, &ec2.RevokeSecurityGroupEgressInput{GroupId: &sgId, IpPermissions: sgEgress}); err != nil {
+			return fmt.Errorf("failed to revoke egress rules from security group %s: %w", sgId, err)
+		}
+	}
+
+	return nil
+}
+
+func (a *action) deleteSecurityGroup(ctx context.Context, sgId string, client *ec2.EC2) error {
+	Log("Deleting Security Group %s", sgId)
+
+	if _, err := client.DeleteSecurityGroupWithContext(ctx, &ec2.DeleteSecurityGroupInput{GroupId: &sgId}); err != nil {
+		return fmt.Errorf("failed to delete security group %s: %w", sgId, err)
+	}
+
+	return nil
+}

--- a/action/errors.go
+++ b/action/errors.go
@@ -5,5 +5,4 @@ import "errors"
 var (
 	ErrAllRegionsNotAllowed = errors.New("all regions is not allowed")
 	ErrRegionsRequired      = errors.New("regions is required")
-	ErrTTLRequired          = errors.New("ttl is required")
 )

--- a/action/input.go
+++ b/action/input.go
@@ -2,17 +2,16 @@ package action
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/caarlos0/env/v9"
 	"go.uber.org/multierr"
 )
 
 type Input struct {
-	Regions        string        `env:"INPUT_REGIONS"`
-	AllowAllRegion bool          `env:"INPUT_ALLOW-ALL-REGIONS"`
-	TTL            time.Duration `env:"INPUT_TTL"`
-	Commit         bool          `env:"INPUT_COMMIT"`
+	Regions        string `env:"INPUT_REGIONS"`
+	AllowAllRegion bool   `env:"INPUT_ALLOW-ALL-REGIONS"`
+	Commit         bool   `env:"INPUT_COMMIT"`
+	IgnoreTag      string `env:"INPUT_IGNORE-TAG"`
 }
 
 // NewInput creates a new input from the environment variables.
@@ -34,10 +33,6 @@ func (i *Input) Validate() error {
 
 	if i.Regions == "*" && !i.AllowAllRegion {
 		err = multierr.Append(err, ErrAllRegionsNotAllowed)
-	}
-
-	if i.TTL.Seconds() == 0 {
-		err = multierr.Append(err, ErrTTLRequired)
 	}
 
 	return err


### PR DESCRIPTION
### Description

This PR adds new functionalities and refactors the rules for deletion:
- `ignore-tag` input parameter: name of the tag that indicates a resource should not be deleted. If not provided, it uses a sensible default `janitor-ignore`.
- `ttl` is no longer used for deletion since janitor now manages deletion of resources that do not have a creation time associated with them. The new approach is mark and delete: the initial execution will mark (using tag `aws-janitor/marked-for-deletion`) for future deletion on all resources that do not have an ignore tag. Next execution will apply deletion on marked resources.
- Supported resources are (in this strict order): EKS Clusters, Auto Scaling Groups, Load Balancers, Security Groups, CloudFormation Stacks. This order is required because of dependencies between resources.

In some specific scenarios, intermittent failures may occur due to dependent resources but these should be fixed in subsequent iterations.

### Comments

After this PR is merged, we'll need to add the janitor to the existing GitHub Action.

Deletion of Security Groups is required for VPC to be deleted from the CloudFormation stack. AWS seems to be slow to delete Security Groups and ingress/egress rules, which can make one Security Group dependent on another. Since there's no way in the SDK to wait for SGs to be deleted, there needs to be a `Sleep` added between triggered deletions. The number of SGs should always be manageable so this is not expected to noticeably affect time of execution.