### PR TITLE
ci: migrate release workflow to publish-image action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,55 +1,52 @@
-name: release
+name: Release
 
 on:
   push:
     tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
-
-env:
-  TAG: ${{ github.ref_name }}
-  REGISTRY: ghcr.io
-
-permissions:
-  contents: write # Allow to create a release.
+    - 'v*'
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  publish-image:
     permissions:
       contents: read
-      packages: write
+      id-token: write
+    runs-on: runs-on,runner=8cpu-linux-x64,run-id=${{ github.run_id }},image=ubuntu22-full-x64
     steps:
-    - name: Checkout
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+    - name: Check out code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - name: "Read secrets"
+      uses: rancher-eio/read-vault-secrets@main
       with:
-        fetch-depth: 0
-    - name: setupGo
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+        secrets: |
+          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD ;
+
+    - name: Push image
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
       with:
-        go-version: '=1.21.3'
-    - name: Docker login
-      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build docker image
-      run: make docker-build-all TAG=${{ env.TAG }}
-    - name: Push docker image
-      run: make docker-push-all TAG=${{ env.TAG }}
+        image: aws-janitor
+        tag: ${{ github.ref_name }}
+        platforms: linux/amd64,linux/arm64
+
+        public-repo: rancher-sandbox
+        public-username: ${{ env.DOCKER_USERNAME }}
+        public-password: ${{ env.DOCKER_PASSWORD }}
+        make-target: push-image
+        push-to-prime: false
+
   release:
-    name: Create draft release
-    needs: build
+    name: Create release
+    needs: publish-image
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Set env
-        run: echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
-      - name: checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-        with:
-          fetch-depth: 0
-      - name: Create draft GH release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create ${{ env.TAG }} --draft --generate-notes
+    - name: Check out code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        fetch-depth: 0
+    - name: Create GH release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release create ${{ github.ref_name }} --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,14 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: "Read secrets"
-      uses: rancher-eio/read-vault-secrets@main
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD ;
 
     - name: Push image
-      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      uses: rancher/ecm-distro-tools/actions/publish-image@5d6e63896fea85836b2fca6dfb9236bcefe2aaa5
       with:
         image: aws-janitor
         tag: ${{ github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,21 @@ export GO111MODULE=on
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
 
+MACHINE := rancher
+
 TAG ?= dev
 ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm64 s390x
+DEFAULT_PLATFORMS := linux/amd64,linux/arm64
 REGISTRY ?= ghcr.io
 ORG ?= rancher-sandbox
 ACTION_IMAGE_NAME ?= aws-janitor
 ACTION_IMG ?= $(REGISTRY)/$(ORG)/$(ACTION_IMAGE_NAME)
 MANIFEST_IMG ?= $(ACTION_IMG)-$(ARCH)
+
+REPO ?= rancher-sandbox
+IMAGE ?= aws-janitor
+IMAGE_NAME ?= $(REPO)/$(IMAGE):$(TAG)
 
 .PHONY: test
 test:
@@ -75,3 +82,27 @@ docker-build: docker-pull-prerequisites ## Run docker-build-* targets for all pr
 docker-list-all:
 	@echo $(CONTROLLER_IMG):${TAG}
 	@for arch in $(ALL_ARCH); do echo $(ACTION_IMG)-$${arch}:${TAG}; done
+
+## --------------------------------------
+## Buildx / publish-image targets
+## --------------------------------------
+
+.PHONY: buildx-machine
+buildx-machine: ## Create rancher buildx machine targeting DEFAULT_PLATFORMS.
+	@docker buildx ls | grep $(MACHINE) || \
+	  docker buildx create --name=$(MACHINE) --platform=$(DEFAULT_PLATFORMS)
+
+.PHONY: push-image
+push-image: ## Build and push multiarch image via docker buildx.
+	docker buildx build \
+	  $(IID_FILE_FLAG) \
+	  $(BUILDX_ARGS) \
+	  --platform=$(TARGET_PLATFORMS) \
+	  --tag $(IMAGE_NAME) \
+	  --push \
+	  .
+
+.PHONY: push-prime-image
+push-prime-image: ## Build and push multiarch image to prime registry with SBOM and provenance attestations.
+	BUILDX_ARGS="--sbom=true --attest type=provenance,mode=max" \
+	$(MAKE) push-image


### PR DESCRIPTION
## What changed

- Replace manual GHCR multi-arch build and push with `rancher/ecm-distro-tools/actions/publish-image`
- Read DockerHub credentials from Vault via `rancher-eio/read-vault-secrets`
- Switch runner to `runs-on` 8cpu-linux-x64 as recommended by Rancher guidelines
- Add `push-image` and `push-prime-image` Makefile targets using `docker buildx`
- Add `buildx-machine` target and `DEFAULT_PLATFORMS` variable
- Add `REPO`, `IMAGE` and `IMAGE_NAME` Makefile variables for publish-image compatibility
- Make `release` job depend on `publish-image` and publish release directly